### PR TITLE
Updates web-eid.js in PHP examples

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.4",
         "web-eid/web-eid-authtoken-validation-php": "1.0.0",
         "altorouter/altorouter": "1.1.0",
-        "guzzlehttp/psr7": "2.4.3",
+        "guzzlehttp/psr7": "2.4.5",
         "psr/log": "^3.0"
     },
     "autoload": {

--- a/examples/public/js/web-eid.js
+++ b/examples/public/js/web-eid.js
@@ -112,7 +112,7 @@ class ExtensionUnavailableError extends Error {
 }
 
 var config = Object.freeze({
-    VERSION: "2.0.0",
+    VERSION: "2.0.1",
     EXTENSION_HANDSHAKE_TIMEOUT: 1000,
     NATIVE_APP_HANDSHAKE_TIMEOUT: 5 * 1000,
     DEFAULT_USER_INTERACTION_TIMEOUT: 2 * 60 * 1000,


### PR DESCRIPTION
Changed PHP examples to use latest version of web-eid.js 2.0.1;
Changed PHP examples to use guzzlehttp/psr7 version 2.4.5 (CVE-2023-29197)