### PR TITLE
Fixed http header names to be treated as case-insensitive

### DIFF
--- a/examples/src/Auth.php
+++ b/examples/src/Auth.php
@@ -97,8 +97,10 @@ class Auth
      */
     public function validate()
     {
-        $headers = getallheaders();
-        if (!isset($headers["X-CSRF-TOKEN"]) || ($headers["X-CSRF-TOKEN"] != $_SESSION["csrf-token"])) {
+        // Header names must be treated as case-insensitive (according to RFC2616) so we convert them to lowercase
+        $headers = array_change_key_case(getallheaders(), CASE_LOWER);
+        
+        if (!isset($headers["x-csrf-token"]) || ($headers["x-csrf-token"] != $_SESSION["csrf-token"])) {
             header("HTTP/1.0 405 Method Not Allowed");
             echo "CSRF token missing, unable to process your request";
             return;


### PR DESCRIPTION
(cherry picked from commit a5f813c13706da2831d566b3f6a5df5192348330)

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Villu Roogna villu.roogna@gmail.com