### PR TITLE
Nonce support was added to EstEID 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ PHP Session is been used for storing the challenge nonce.
 
 You must explicitly specify which **intermediate** certificate authorities (CAs) are trusted to issue the eID authentication and OCSP responder certificates. CA certificates can be loaded from resources.
 
-First, copy the trusted certificates, for example `ESTEID-SK_2015.der.cer` and `ESTEID2018.der.cer`, to `certificates/` folder, then load the certificates as follows:
+First, copy the trusted certificates, for example `ESTEID2018.der.cer`, to `certificates/` folder, then load the certificates as follows:
 
 ```php
 use web_eid\web_eid_authtoken_validation_php\certificate\CertificateLoader;
@@ -76,7 +76,7 @@ use web_eid\web_eid_authtoken_validation_php\certificate\CertificateLoader;
 public function trustedIntermediateCACertificates(): array
 {
     return CertificateLoader::loadCertificatesFromResources(
-        __DIR__ . "/../certificates/ESTEID2018.cer", __DIR__ . "/../certificates/ESTEID-SK_2015.cer"
+        __DIR__ . "/../certificates/ESTEID2018.cer"
     );
 }
 ...
@@ -296,7 +296,7 @@ The following additional configuration options are available in `AuthTokenValida
 
 - `withDisallowedCertificatePolicies(string ...$policies)` – adds the given policies to the list of disallowed user certificate policies. In order for the user certificate to be considered valid, it must not contain any policies present in this list. Contains the Estonian Mobile-ID policies by default as it must not be possible to authenticate with a Mobile-ID certificate when an eID smart card is expected.
 
-- `withNonceDisabledOcspUrls(URI ...$urls)` – adds the given URLs to the list of OCSP responder access location URLs for which the nonce protocol extension will be disabled. Some OCSP responders don't support the nonce extension. Contains the ESTEID-2015 OCSP responder URL by default.
+- `withNonceDisabledOcspUrls(URI ...$urls)` – adds the given URLs to the list of OCSP responder access location URLs for which the nonce protocol extension will be disabled. Some OCSP responders don't support the nonce extension.
 
 Extended configuration example:  
 

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "web-eid/web-eid-authtoken-validation-php": "1.0.0",
+        "web-eid/web-eid-authtoken-validation-php": "1.1.0",
         "altorouter/altorouter": "1.1.0",
         "guzzlehttp/psr7": "2.4.5",
         "psr/log": "^3.0"

--- a/examples/src/Auth.php
+++ b/examples/src/Auth.php
@@ -40,8 +40,7 @@ class Auth
     public function trustedIntermediateCACertificates(): array
     {
         return CertificateLoader::loadCertificatesFromResources(
-            __DIR__ . "/../certificates/esteid2018.der.crt",
-            __DIR__ . "/../certificates/ESTEID-SK_2015.der.crt"
+            __DIR__ . "/../certificates/esteid2018.der.crt"
         );
     }
 

--- a/src/validator/AuthTokenValidationConfiguration.php
+++ b/src/validator/AuthTokenValidationConfiguration.php
@@ -30,7 +30,6 @@ use web_eid\web_eid_authtoken_validation_php\certificate\SubjectCertificatePolic
 use GuzzleHttp\Psr7\Uri;
 use web_eid\web_eid_authtoken_validation_php\util\DateAndTime;
 use web_eid\web_eid_authtoken_validation_php\util\UriCollection;
-use web_eid\web_eid_authtoken_validation_php\validator\ocsp\OcspUrl;
 
 use InvalidArgumentException;
 use web_eid\web_eid_authtoken_validation_php\validator\ocsp\service\DesignatedOcspServiceConfiguration;
@@ -57,7 +56,7 @@ final class AuthTokenValidationConfiguration
             SubjectCertificatePolicies::$ESTEID_SK_2015_MOBILE_ID_POLICY_V3,
             SubjectCertificatePolicies::$ESTEID_SK_2015_MOBILE_ID_POLICY
         ];
-        $this->nonceDisabledOcspUrls = new UriCollection(new Uri(OcspUrl::AIA_ESTEID_2015_URL));
+        $this->nonceDisabledOcspUrls = new UriCollection();
     }
 
     public function setSiteOrigin(Uri $siteOrigin): void

--- a/src/validator/ocsp/OcspUrl.php
+++ b/src/validator/ocsp/OcspUrl.php
@@ -31,8 +31,6 @@ use Exception;
 
 final class OcspUrl
 {
-    public const AIA_ESTEID_2015_URL = "http://aia.sk.ee/esteid2015";
-
     public function __construct()
     {
         throw new BadFunctionCallException("Utility class");

--- a/tests/testutil/OcspServiceMaker.php
+++ b/tests/testutil/OcspServiceMaker.php
@@ -29,7 +29,6 @@ use GuzzleHttp\Psr7\Uri;
 use web_eid\web_eid_authtoken_validation_php\util\UriCollection;
 use web_eid\web_eid_authtoken_validation_php\util\X509Collection;
 use web_eid\web_eid_authtoken_validation_php\validator\ocsp\OcspServiceProvider;
-use web_eid\web_eid_authtoken_validation_php\validator\ocsp\OcspUrl;
 use web_eid\web_eid_authtoken_validation_php\validator\ocsp\service\AiaOcspServiceConfiguration;
 use web_eid\web_eid_authtoken_validation_php\validator\ocsp\service\DesignatedOcspServiceConfiguration;
 
@@ -52,7 +51,7 @@ class OcspServiceMaker
     private static function getAiaOcspServiceConfiguration(): AiaOcspServiceConfiguration
     {
         return new AiaOcspServiceConfiguration(
-            new UriCollection(new Uri(OcspUrl::AIA_ESTEID_2015_URL), new Uri(self::TEST_ESTEID_2015)),
+            new UriCollection(new Uri(self::TEST_ESTEID_2015)),
             CertificateValidator::buildTrustFromCertificates([Certificates::getTestEsteid2018CA(), Certificates::getTestEsteid2018CAGov(), Certificates::getTestEsteid2015CA()])
         );
     }


### PR DESCRIPTION
+ All ID-Card certificates are expired in this service

WE2-839

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
