### PR TITLE
fix: use system time in OcspResponseValidator.validateCertificateStatusUpdateTime()

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ The following additional configuration options are available in `AuthTokenValida
 
 - `withNonceDisabledOcspUrls(URI ...$urls)` – adds the given URLs to the list of OCSP responder access location URLs for which the nonce protocol extension will be disabled. Some OCSP responders don't support the nonce extension.
 
+- `withAllowedOcspResponseTimeSkew(int $allowedTimeSkew)` – sets the allowed time skew for OCSP response's `thisUpdate` and `nextUpdate` times to allow discrepancies between the system clock and the OCSP responder's clock or revocation updates that are not published in real time. The default allowed time skew is 15 minutes. The relatively long default is specifically chosen to account for one particular OCSP responder that used CRLs for authoritative revocation info, these CRLs were updated every 15 minutes.
+
+- `withMaxOcspResponseThisUpdateAge(int $maxThisUpdateAge)` – sets the maximum age for the OCSP response's `thisUpdate` time before it is considered too old to rely on. The default maximum age is 2 minutes.
+
+
 Extended configuration example:  
 
 ```php

--- a/src/util/DateAndTime.php
+++ b/src/util/DateAndTime.php
@@ -78,38 +78,3 @@ final class DateAndTime
         return ((clone $date)->setTimezone(new DateTimeZone("UTC")))->format("Y-m-d H:i:s e");
     }
 }
-
-/**
- * @copyright 2022 Petr Muzikant pmuzikant@email.cz
- */
-final class DefaultClock
-{
-    private static DefaultClock $instance;
-    private DateTime $mockedClock;
-
-    public static function getInstance()
-    {
-        if (!isset(self::$instance)) {
-            self::$instance = new DefaultClock();
-        }
-        return self::$instance;
-    }
-
-    public function now(): DateTime
-    {
-        if (isset($this->mockedClock)) {
-            return $this->mockedClock;
-        }
-        return new DateTime();
-    }
-
-    public function setClock(DateTime $mockedClock): void
-    {
-        $this->mockedClock = $mockedClock;
-    }
-
-    public function resetClock(): void
-    {
-        unset($this->mockedClock);
-    }
-}

--- a/src/util/DefaultClock.php
+++ b/src/util/DefaultClock.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2022-2024 Estonian Information System Authority
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace web_eid\web_eid_authtoken_validation_php\util;
+
+use DateTime;
+
+/**
+ * @copyright 2022 Petr Muzikant pmuzikant@email.cz
+ */
+final class DefaultClock
+{
+    private static DefaultClock $instance;
+    private DateTime $mockedClock;
+
+    public static function getInstance()
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new DefaultClock();
+        }
+        return self::$instance;
+    }
+
+    public function now(): DateTime
+    {
+        if (isset($this->mockedClock)) {
+            return $this->mockedClock;
+        }
+        return new DateTime();
+    }
+
+    public function setClock(DateTime $mockedClock): void
+    {
+        $this->mockedClock = $mockedClock;
+    }
+
+    public function resetClock(): void
+    {
+        unset($this->mockedClock);
+    }
+}

--- a/src/validator/AuthTokenValidationConfiguration.php
+++ b/src/validator/AuthTokenValidationConfiguration.php
@@ -39,7 +39,9 @@ final class AuthTokenValidationConfiguration
     private ?Uri $siteOrigin = null;
     private array $trustedCACertificates = [];
     private bool $isUserCertificateRevocationCheckWithOcspEnabled = true;
-    private int $ocspRequestTimeout = 5;
+    private int $ocspRequestTimeout = 5; // In seconds
+    private int $allowedOcspResponseTimeSkew = 15; // In minutes
+    private int $maxOcspResponseThisUpdateAge = 2; // In minutes
     private array $disallowedSubjectCertificatePolicies;
     private UriCollection $nonceDisabledOcspUrls;
     private ?DesignatedOcspServiceConfiguration $designatedOcspServiceConfiguration = null;
@@ -94,6 +96,26 @@ final class AuthTokenValidationConfiguration
         $this->ocspRequestTimeout = $ocspRequestTimeout;
     }
 
+    public function getAllowedOcspResponseTimeSkew(): int
+    {
+        return $this->allowedOcspResponseTimeSkew;
+    }
+
+    public function setAllowedOcspResponseTimeSkew(int $allowedOcspResponseTimeSkew): void
+    {
+        $this->allowedOcspResponseTimeSkew = $allowedOcspResponseTimeSkew;
+    }
+
+    public function getMaxOcspResponseThisUpdateAge(): int
+    {
+        return $this->maxOcspResponseThisUpdateAge;
+    }
+
+    public function setMaxOcspResponseThisUpdateAge(int $maxOcspResponseThisUpdateAge): void
+    {
+        $this->maxOcspResponseThisUpdateAge = $maxOcspResponseThisUpdateAge;
+    }
+
     public function getDesignatedOcspServiceConfiguration(): ?DesignatedOcspServiceConfiguration
     {
         return $this->designatedOcspServiceConfiguration;
@@ -132,6 +154,8 @@ final class AuthTokenValidationConfiguration
         }
 
         DateAndTime::requirePositiveDuration($this->ocspRequestTimeout, "OCSP request timeout");
+        DateAndTime::requirePositiveDuration($this->allowedOcspResponseTimeSkew, "Allowed OCSP response time-skew");
+        DateAndTime::requirePositiveDuration($this->maxOcspResponseThisUpdateAge, "Max OCSP response thisUpdate age");
     }
 
     /**

--- a/src/validator/AuthTokenValidatorBuilder.php
+++ b/src/validator/AuthTokenValidatorBuilder.php
@@ -126,6 +126,40 @@ class AuthTokenValidatorBuilder
         $this->logger?->debug("OCSP request timeout set to " . $ocspRequestTimeout);
         return $this;
     }
+    
+    /**
+     * Sets the allowed time skew for OCSP response's thisUpdate and nextUpdate times.
+     * This parameter is used to allow discrepancies between the system clock and the OCSP responder's clock,
+     * which may occur due to clock drift, network delays or revocation updates that are not published in real time.
+     * <p>
+     * This is an optional configuration parameter, the default is 15 minutes.
+     * The relatively long default is specifically chosen to account for one particular OCSP responder that used
+     * CRLs for authoritative revocation info, these CRLs were updated every 15 minutes.
+     * 
+     * @param integer $allowedTimeSkew the allowed time skew
+     * @return AuthTokenValidatorBuilder the builder instance for method chaining.
+     */
+    public function withAllowedOcspResponseTimeSkew(int $allowedTimeSkew) : AuthTokenValidatorBuilder
+    {
+        $this->configuration->setAllowedOcspResponseTimeSkew($allowedTimeSkew);
+        $this->logger?->debug("Allowed OCSP response time skew set to " . $allowedTimeSkew);
+        return $this;
+    }
+
+    /**
+     * Sets the maximum age of the OCSP response's thisUpdate time before it is considered too old.
+     * <p>
+     * This is an optional configuration parameter, the default is 2 minutes.
+     * 
+     * @param integer $maxThisUpdateAge the maximum age of the OCSP response's thisUpdate time
+     * @return AuthTokenValidatorBuilder the builder instance for method chaining.
+     */
+    public function withMaxOcspResponseThisUpdateAge(int $maxThisUpdateAge) : AuthTokenValidatorBuilder
+    {
+        $this->configuration->setMaxOcspResponseThisUpdateAge($maxThisUpdateAge);
+        $this->logger?->debug("Maximum OCSP response thisUpdate age set to " . $maxThisUpdateAge);
+        return $this;
+    }
 
     /**
      * Adds the given URLs to the list of OCSP URLs for which the nonce protocol extension will be disabled.

--- a/src/validator/AuthTokenValidatorImpl.php
+++ b/src/validator/AuthTokenValidatorImpl.php
@@ -172,7 +172,12 @@ final class AuthTokenValidatorImpl implements AuthTokenValidator
         if ($this->configuration->isUserCertificateRevocationCheckWithOcspEnabled()) {
             $validatorBatch->addOptional(
                 $this->configuration->isUserCertificateRevocationCheckWithOcspEnabled(),
-                new SubjectCertificateNotRevokedValidator($certTrustedValidator, $this->ocspClient, $this->ocspServiceProvider, $this->logger)
+                new SubjectCertificateNotRevokedValidator($certTrustedValidator, 
+                    $this->ocspClient, 
+                    $this->ocspServiceProvider,
+                    $this->configuration->getAllowedOcspResponseTimeSkew(),
+                    $this->configuration->getMaxOcspResponseThisUpdateAge(), 
+                    $this->logger)
             );
         }
 

--- a/src/validator/certvalidators/SubjectCertificateNotRevokedValidator.php
+++ b/src/validator/certvalidators/SubjectCertificateNotRevokedValidator.php
@@ -37,6 +37,7 @@ use web_eid\ocsp_php\OcspResponse;
 use web_eid\web_eid_authtoken_validation_php\exceptions\UserCertificateOCSPCheckFailedException;
 use web_eid\web_eid_authtoken_validation_php\validator\ocsp\service\OcspService;
 use Psr\Log\LoggerInterface;
+use web_eid\web_eid_authtoken_validation_php\util\DefaultClock;
 
 final class SubjectCertificateNotRevokedValidator implements SubjectCertificateValidator
 {
@@ -137,8 +138,9 @@ final class SubjectCertificateNotRevokedValidator implements SubjectCertificateV
         //   4. The signer is currently authorized to provide a response for the
         //      certificate in question.
 
-        $producedAt = $basicResponse->getProducedAt();
-        $ocspService->validateResponderCertificate($responderCert, $producedAt);
+        // Use the DefaultClock instance so that the date can be mocked in tests.
+        $now = DefaultClock::getInstance()->now();
+        $ocspService->validateResponderCertificate($responderCert, $now);
         //   5. The time at which the status being indicated is known to be
         //      correct (thisUpdate) is sufficiently recent.
         //

--- a/src/validator/ocsp/OcspClientImpl.php
+++ b/src/validator/ocsp/OcspClientImpl.php
@@ -75,8 +75,6 @@ class OcspClientImpl implements OcspClient
         $responseJson = json_encode($response->getResponse(), JSON_INVALID_UTF8_IGNORE);
         $this->logger?->debug("OCSP response: " . $responseJson);
 
-        echo $uri;
-
         if ($info["content_type"] !== self::OCSP_RESPONSE_TYPE) {
             throw new UserCertificateOCSPCheckFailedException("OCSP response content type is not " . self::OCSP_RESPONSE_TYPE);
         }

--- a/src/validator/ocsp/OcspClientImpl.php
+++ b/src/validator/ocsp/OcspClientImpl.php
@@ -75,6 +75,8 @@ class OcspClientImpl implements OcspClient
         $responseJson = json_encode($response->getResponse(), JSON_INVALID_UTF8_IGNORE);
         $this->logger?->debug("OCSP response: " . $responseJson);
 
+        echo $uri;
+
         if ($info["content_type"] !== self::OCSP_RESPONSE_TYPE) {
             throw new UserCertificateOCSPCheckFailedException("OCSP response content type is not " . self::OCSP_RESPONSE_TYPE);
         }

--- a/src/validator/ocsp/OcspResponseValidator.php
+++ b/src/validator/ocsp/OcspResponseValidator.php
@@ -26,7 +26,6 @@ namespace web_eid\web_eid_authtoken_validation_php\validator\ocsp;
 
 use BadFunctionCallException;
 use DateInterval;
-use DateTime;
 use web_eid\web_eid_authtoken_validation_php\exceptions\OCSPCertificateException;
 use phpseclib3\File\X509;
 use web_eid\ocsp_php\OcspBasicResponse;

--- a/src/validator/ocsp/service/AiaOcspService.php
+++ b/src/validator/ocsp/service/AiaOcspService.php
@@ -63,9 +63,9 @@ class AiaOcspService implements OcspService
         return $this->url;
     }
 
-    public function validateResponderCertificate(X509 $cert, DateTime $producedAt): void
+    public function validateResponderCertificate(X509 $cert, DateTime $now): void
     {
-        CertificateValidator::certificateIsValidOnDate($cert, $producedAt, "AIA OCSP responder");
+        CertificateValidator::certificateIsValidOnDate($cert, $now, "AIA OCSP responder");
         // Trusted certificates' validity has been already verified in validateCertificateExpiry().
         OcspResponseValidator::validateHasSigningExtension($cert);
         CertificateValidator::validateIsValidAndSignedByTrustedCA($cert, $this->trustedCACertificates);

--- a/src/validator/ocsp/service/DesignatedOcspService.php
+++ b/src/validator/ocsp/service/DesignatedOcspService.php
@@ -59,13 +59,13 @@ class DesignatedOcspService implements OcspService
         return $this->configuration->supportsIssuerOf($certificate);
     }
 
-    public function validateResponderCertificate(X509 $cert, DateTime $producedAt): void
+    public function validateResponderCertificate(X509 $cert, DateTime $now): void
     {
         // Certificate pinning is implemented simply by comparing the certificates or their public keys,
         // see https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning.
         if ($this->configuration->getResponderCertificate()->getCurrentCert() != $cert->getCurrentCert()) {
             throw new OCSPCertificateException("Responder certificate from the OCSP response is not equal to the configured designated OCSP responder certificate");
         }
-        CertificateValidator::certificateIsValidOnDate($cert, $producedAt, "Designated OCSP responder");
+        CertificateValidator::certificateIsValidOnDate($cert, $now, "Designated OCSP responder");
     }
 }

--- a/tests/testutil/AuthTokenValidators.php
+++ b/tests/testutil/AuthTokenValidators.php
@@ -58,6 +58,11 @@ final class AuthTokenValidators
         return (self::getAuthTokenValidatorBuilder(self::TOKEN_ORIGIN_URL, self::getCACertificates()))->withDesignatedOcspServiceConfiguration(OcspServiceMaker::getDesignatedOcspServiceConfiguration())->build();
     }
 
+    public static function getDefaultAuthTokenValidatorBuilder(): AuthTokenValidatorBuilder
+    {
+        return self::getAuthTokenValidatorBuilder(self::TOKEN_ORIGIN_URL, self::getCACertificates());
+    }
+
     private static function getAuthTokenValidatorBuilder(string $uri, array $certificates): AuthTokenValidatorBuilder
     {
         return (new AuthTokenValidatorBuilder(new Logger()))

--- a/tests/validator/AuthTokenValidatorBuilderTest.php
+++ b/tests/validator/AuthTokenValidatorBuilderTest.php
@@ -24,12 +24,12 @@
 
 namespace web_eid\web_eid_authtoken_validation_php\validator;
 
-use GuzzleHttp\Psr7\Exception\MalformedUriException;
-use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
 use GuzzleHttp\Psr7\Uri;
-use web_eid\web_eid_authtoken_validation_php\testutil\AuthTokenValidators;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Exception\MalformedUriException;
 use web_eid\web_eid_authtoken_validation_php\testutil\Logger;
+use web_eid\web_eid_authtoken_validation_php\testutil\AuthTokenValidators;
 
 class AuthTokenValidatorBuilderTest extends TestCase
 {
@@ -89,5 +89,29 @@ class AuthTokenValidatorBuilderTest extends TestCase
         $this->expectException(MalformedUriException::class);
         $this->expectExceptionMessage("Unable to parse URI: https:///ria.ee");
         AuthTokenValidators::getAuthTokenValidator("https:///ria.ee");
+    }
+
+    public function testInvalidOcspResponseTimeSkew() : void
+    {
+        $builderWithInvalidResponseTimeSkew = AuthTokenValidators::getDefaultAuthTokenValidatorBuilder()->withAllowedOcspResponseTimeSkew(-1);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Allowed OCSP response time-skew must be greater than zero");
+        $builderWithInvalidResponseTimeSkew->build();
+    }
+
+    public function testInvalidMaxOcspResponseThisUpdateAge() : void
+    {
+        $builderWithInvalidMaxOcspResponseThisUpdateAge = AuthTokenValidators::getDefaultAuthTokenValidatorBuilder()->withMaxOcspResponseThisUpdateAge(0);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Max OCSP response thisUpdate age must be greater than zero");
+        $builderWithInvalidMaxOcspResponseThisUpdateAge->build();
+    }
+
+    public function testInvalidOcspRequestTimeout() : void
+    {
+        $builderWithInvalidOcspRequestTimeout = AuthTokenValidators::getDefaultAuthTokenValidatorBuilder()->withOcspRequestTimeout(-1);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("OCSP request timeout must be greater than zero");
+        $builderWithInvalidOcspRequestTimeout->build();
     }
 }

--- a/tests/validator/ocsp/OcspResponseValidatorTest.php
+++ b/tests/validator/ocsp/OcspResponseValidatorTest.php
@@ -30,9 +30,10 @@ use DateTime;
 use DateInterval;
 use PHPUnit\Framework\TestCase;
 use web_eid\ocsp_php\OcspBasicResponse;
+use web_eid\web_eid_authtoken_validation_php\util\DateAndTime;
+use web_eid\web_eid_authtoken_validation_php\util\DefaultClock;
 use web_eid\web_eid_authtoken_validation_php\validator\AuthTokenValidationConfiguration;
 use web_eid\web_eid_authtoken_validation_php\exceptions\UserCertificateOCSPCheckFailedException;
-use web_eid\web_eid_authtoken_validation_php\util\DateAndTime;
 
 class OcspResponseValidatorTest extends TestCase
 {
@@ -51,7 +52,7 @@ class OcspResponseValidatorTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $now = new DateTime();
+        $now = DefaultClock::getInstance()->now();
         $thisUpdateWithinAgeLimit = self::getThisUpdateWithinAgeLimit($now);
         $nextUpdateWithinAgeLimit = (clone $now)->add(new DateInterval('PT' . 2 . 'S'))->sub(new DateInterval('PT' . self::$maxThisUpdateAge . 'M'));
         $response = [];
@@ -67,7 +68,7 @@ class OcspResponseValidatorTest extends TestCase
 
     public function testWhenNextUpdateBeforeThisUpdateThenThrows(): void
     {
-        $now = new DateTime();
+        $now = DefaultClock::getInstance()->now();
         $thisUpdateWithinAgeLimit = self::getThisUpdateWithinAgeLimit($now);
         $beforeThisUpdate = (clone $thisUpdateWithinAgeLimit)->sub(new DateInterval('PT1S'));
         $response = [];
@@ -87,8 +88,9 @@ class OcspResponseValidatorTest extends TestCase
         OcspResponseValidator::validateCertificateStatusUpdateTime($mockBasicResponse, self::$timeSkew, self::$maxThisUpdateAge);
     }
 
-    public function testWhenThisUpdateHalfHourBeforeNowThenThrows(): void {
-        $now = new DateTime();
+    public function testWhenThisUpdateHalfHourBeforeNowThenThrows(): void
+    {
+        $now = DefaultClock::getInstance()->now();
         $halfHourBeforeNow = (clone $now)->sub(new DateInterval('PT30M'));
         $response = [];
         $response['tbsResponseData']['responses'] = [];
@@ -106,8 +108,9 @@ class OcspResponseValidatorTest extends TestCase
         OcspResponseValidator::validateCertificateStatusUpdateTime($mockBasicResponse, self::$timeSkew, self::$maxThisUpdateAge);
     }
 
-    public function testWhenThisUpdateHalfHourAfterNowThenThrows(): void {
-        $now = new DateTime();
+    public function testWhenThisUpdateHalfHourAfterNowThenThrows(): void
+    {
+        $now = DefaultClock::getInstance()->now();
         $halfHourAfterNow = (clone $now)->add(new DateInterval('PT30M'));
         $response = [];
         $response['tbsResponseData']['responses'] = [];
@@ -127,7 +130,7 @@ class OcspResponseValidatorTest extends TestCase
 
     public function testWhenNextUpdateHalfHourBeforeNowThenThrows(): void
     {
-        $now = new DateTime();
+        $now = DefaultClock::getInstance()->now();
         $thisUpdateWithinAgeLimit = self::getThisUpdateWithinAgeLimit($now);
         $halfHourBeforeNow = (clone $now)->sub(new DateInterval('PT30M'));
         $response = [];
@@ -149,6 +152,6 @@ class OcspResponseValidatorTest extends TestCase
 
     private static function getThisUpdateWithinAgeLimit(DateTime $now): DateTime
     {
-        return (clone $now)->add(new DateInterval('PT' . 1 . 'S'))->sub(new DateInterval('PT' . self::$maxThisUpdateAge . 'M'));        
+        return (clone $now)->add(new DateInterval('PT' . 1 . 'S'))->sub(new DateInterval('PT' . self::$maxThisUpdateAge . 'M'));
     }
 }


### PR DESCRIPTION
Fixes the same issue that was fixed in Java with [this pull request.](https://github.com/web-eid/web-eid-authtoken-validation-java/pull/55)

WE2-984

Signed-off-by: Mihkel Kivisild mihkel.kivisild@cgi.com
