### PR TITLE
Allow optional fields in organization certificates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -615,16 +615,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.2.0",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb"
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
                 "shasum": ""
             },
             "require": {
@@ -667,9 +667,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.2.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
             },
-            "time": "2024-09-15T16:40:33+00:00"
+            "time": "2024-10-08T18:51:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1112,16 +1112,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.34",
+            "version": "10.5.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3c69d315bdf79080c8e115b69d1961c6905b0e18"
+                "reference": "a86773b9e887a67bc53efa9da9ad6e3f2498c132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3c69d315bdf79080c8e115b69d1961c6905b0e18",
-                "reference": "3c69d315bdf79080c8e115b69d1961c6905b0e18",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a86773b9e887a67bc53efa9da9ad6e3f2498c132",
+                "reference": "a86773b9e887a67bc53efa9da9ad6e3f2498c132",
                 "shasum": ""
             },
             "require": {
@@ -1142,7 +1142,7 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.2",
+                "sebastian/comparator": "^5.0.3",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
                 "sebastian/exporter": "^5.1.2",
@@ -1193,7 +1193,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.38"
             },
             "funding": [
                 {
@@ -1209,7 +1209,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-13T05:19:38+00:00"
+            "time": "2024-10-28T13:06:21+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1381,16 +1381,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2d3e04c3b4c1e84a5e7382221ad8883c8fbc4f53"
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2d3e04c3b4c1e84a5e7382221ad8883c8fbc4f53",
-                "reference": "2d3e04c3b4c1e84a5e7382221ad8883c8fbc4f53",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
                 "shasum": ""
             },
             "require": {
@@ -1401,7 +1401,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.4"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -1446,7 +1446,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1454,7 +1454,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-12T06:03:08+00:00"
+            "time": "2024-10-18T14:56:07+00:00"
         },
         {
             "name": "sebastian/complexity",

--- a/example/composer.lock
+++ b/example/composer.lock
@@ -67,16 +67,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.6.2",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
+                "reference": "6de29867b18790c0d2c846af4c13a24cc3ad56f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
-                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/6de29867b18790c0d2c846af4c13a24cc3ad56f3",
+                "reference": "6de29867b18790c0d2c846af4c13a24cc3ad56f3",
                 "shasum": ""
             },
             "require": {
@@ -91,8 +91,8 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -163,7 +163,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.3"
             },
             "funding": [
                 {
@@ -179,7 +179,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-03T20:05:35+00:00"
+            "time": "2024-07-18T09:59:12+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -300,16 +300,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.39",
+            "version": "3.0.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485"
+                "reference": "db92f1b1987b12b13f248fe76c3a52cadb67bb98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/211ebc399c6e73c225a018435fe5ae209d1d1485",
-                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/db92f1b1987b12b13f248fe76c3a52cadb67bb98",
+                "reference": "db92f1b1987b12b13f248fe76c3a52cadb67bb98",
                 "shasum": ""
             },
             "require": {
@@ -390,7 +390,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.39"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.42"
             },
             "funding": [
                 {
@@ -406,7 +406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-24T06:27:33+00:00"
+            "time": "2024-09-16T03:06:04+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -518,16 +518,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -562,9 +562,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -719,5 +719,5 @@
         "php": ">=8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/certificate/CertificateData.php
+++ b/src/certificate/CertificateData.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
 namespace web_eid\web_eid_authtoken_validation_php\certificate;
 
 use phpseclib3\File\X509;
-use UnexpectedValueException;
 use BadFunctionCallException;
 
 final class CertificateData
@@ -40,50 +39,40 @@ final class CertificateData
 
     /**
      * Get commonName from x509 certificate
-     *
-     * @throws UnexpectedValueException
      */
-    public static function getSubjectCN(X509 $certificate): string
+    public static function getSubjectCN(X509 $certificate): ?string
     {
         return self::getField($certificate, 'id-at-commonName');
     }
 
     /**
      * Get surname from x509 certificate
-     *
-     * @throws UnexpectedValueException
      */
-    public static function getSubjectSurname(X509 $certificate): string
+    public static function getSubjectSurname(X509 $certificate): ?string
     {
         return self::getField($certificate, 'id-at-surname');
     }
 
     /**
      * Get given name from x509 certificate
-     *
-     * @throws UnexpectedValueException
      */
-    public static function getSubjectGivenName(X509 $certificate): string
+    public static function getSubjectGivenName(X509 $certificate): ?string
     {
         return self::getField($certificate, 'id-at-givenName');
     }
 
     /**
      * Get serialNumber (ID-code) from x509 certificate
-     *
-     * @throws UnexpectedValueException
      */
-    public static function getSubjectIdCode(X509 $certificate): string
+    public static function getSubjectIdCode(X509 $certificate): ?string
     {
         return self::getField($certificate, 'id-at-serialNumber');
     }
 
     /**
      * Get country code from x509 certificate
-     *
-     * @throws UnexpectedValueException
      */
-    public static function getSubjectCountryCode(X509 $certificate): string
+    public static function getSubjectCountryCode(X509 $certificate): ?string
     {
         return self::getField($certificate, 'id-at-countryName');
     }
@@ -91,15 +80,16 @@ final class CertificateData
     /**
      * Get specified subject field from x509 certificate
      *
-     * @throws UnexpectedValueException field identifier not found
      * @return string
      */
-    private static function getField(X509 $certificate, string $fieldId): string
+    private static function getField(X509 $certificate, string $fieldId): ?string
     {
         $result = $certificate->getSubjectDNProp($fieldId);
         if ($result) {
-            return $result[0];
+            return join(" ", $result);
         }
-        throw new UnexpectedValueException("fieldId " . $fieldId . " not found in certificate subject");
+        else {
+            return null;
+        }
     }
 }

--- a/tests/certificate/CertificateDataTest.php
+++ b/tests/certificate/CertificateDataTest.php
@@ -49,32 +49,25 @@ class CertificateDataTest extends TestCase
         $this->assertEquals("EE", CertificateData::getSubjectCountryCode($cert));
     }
 
-    public function testWhenOrganizationCertificateThenSubjectGivenNameExtractionFails(): void
+    public function testWhenOrganizationCertificateThenSubjectGivenNameAndSurnameAreNull(): void
     {
         $cert = Certificates::getOrganizationCert();
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage("fieldId id-at-givenName not found in certificate subject");
-        CertificateData::getSubjectGivenName($cert);
-    }
-
-    public function testWhenOrganizationCertificateThenSubjectSurnameExtractionFails(): void
-    {
-        $cert = Certificates::getOrganizationCert();
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage("fieldId id-at-surname not found in certificate subject");
-        CertificateData::getSubjectSurname($cert);
+        $this->assertEquals(null, CertificateData::getSubjectGivenName($cert));
+        $this->assertEquals(null, CertificateData::getSubjectSurname($cert));
     }
 
     public function testWhenOrganizationCertificateThenSucceeds(): void
     {
         $cert = Certificates::getOrganizationCert();
-        try {
-            $principalName = CertificateData::getSubjectSurname($cert) . " " . CertificateData::getSubjectSurname($cert);
-        } catch (UnexpectedValueException $e) {
+        $surname = CertificateData::getSubjectSurname($cert);
+        $givenname = CertificateData::getSubjectGivenName($cert);
+        if ($surname && $givenname) {
+            $principalName = $givenname . " " . $surname;
+        } else {
             $principalName = CertificateData::getSubjectCN($cert);
         }
+        
         $this->assertEquals("Testijad.ee isikutuvastus", $principalName);
 
     }
-
 }


### PR DESCRIPTION
Add support for organization certificates.
All `.der.crt` files from the `certificates` folder will be loaded in the example as trusted intermediate CA certificates

WE2-999

Signed-off-by: Mihkel Kivisild <mihkel.kivisild@cgi.com>