### PR TITLE
Add customizable hash algorithm for generating certificate ID

### DIFF
--- a/src/util/AsnUtil.php
+++ b/src/util/AsnUtil.php
@@ -43,16 +43,20 @@ final class AsnUtil
 
         // ASN.1 format: 0x30 b1 0x02 b2 r 0x02 b3 s.
         // Note: unpack() returns an array indexed from 1, not 0.
-        if(!isset($sigByteArray[1]) ||
+        if (
+            !isset($sigByteArray[1]) ||
             !isset($sigByteArray[2]) ||
             !isset($sigByteArray[3]) ||
-            !isset($sigByteArray[4])) {
+            !isset($sigByteArray[4])
+        ) {
             return false;
         }
         $b1 = $sigByteArray[2];
         $b2 = $sigByteArray[4];
-        if(!isset($sigByteArray[5 + $b2]) ||
-            !isset($sigByteArray[6 + $b2])) {
+        if (
+            !isset($sigByteArray[5 + $b2]) ||
+            !isset($sigByteArray[6 + $b2])
+        ) {
             return false;
         }
         $b3 = $sigByteArray[6 + $b2];
@@ -108,6 +112,13 @@ final class AsnUtil
         ASN1::loadOIDs([
             "id-pkix-ocsp-nonce" => self::ID_PKIX_OCSP_NONCE,
             "id-sha1" => "1.3.14.3.2.26",
+            'id-sha256' => '2.16.840.1.101.3.4.2.1',
+            'id-sha384' => '2.16.840.1.101.3.4.2.2',
+            'id-sha512' => '2.16.840.1.101.3.4.2.3',
+            'id-sha224' => '2.16.840.1.101.3.4.2.4',
+            'id-sha512/224' => '2.16.840.1.101.3.4.2.5',
+            'id-sha512/256' => '2.16.840.1.101.3.4.2.6',
+            'id-mgf1' => '1.2.840.113549.1.1.8',
             "sha256WithRSAEncryption" => "1.2.840.113549.1.1.11",
             "qcStatements(3)" => "1.3.6.1.5.5.7.1.3",
             "street" => "2.5.4.9",

--- a/src/util/HashAlgorithm.php
+++ b/src/util/HashAlgorithm.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace web_eid\web_eid_authtoken_validation_php\util;
+
+enum HashAlgorithm: string
+{
+    case SHA1 = "sha1";
+    case SHA256 = "sha256";
+    case SHA384 = "sha384";
+    case SHA512 = "sha512";
+    case SHA224 = "sha224";
+    case SHA512_224 = "sha512/224";
+    case SHA512_256 = "sha512/256";
+    case MGF1 = "mgf1";
+}

--- a/tests/ocsp/OcspTest.php
+++ b/tests/ocsp/OcspTest.php
@@ -30,6 +30,7 @@ use phpseclib3\File\X509;
 use PHPUnit\Framework\TestCase;
 use web_eid\web_eid_authtoken_validation_php\ocsp\certificate\CertificateLoader;
 use web_eid\web_eid_authtoken_validation_php\ocsp\exceptions\OcspCertificateException;
+use web_eid\web_eid_authtoken_validation_php\util\HashAlgorithm;
 
 class OcspTest extends TestCase
 {
@@ -41,6 +42,19 @@ class OcspTest extends TestCase
         $this->assertEquals("1.3.14.3.2.26", $result['hashAlgorithm']['algorithm']);
         $this->assertEquals([126, 230, 106, 231, 114, 154, 179, 252, 248, 162, 32, 100, 108, 22, 161, 45, 96, 113, 8, 93], array_values(unpack('C*', $result['issuerNameHash'])));
         $this->assertEquals([168, 74, 106, 99, 4, 125, 221, 186, 230, 209, 57, 183, 166, 69, 101, 239, 243, 168, 236, 161], array_values(unpack('C*', $result['issuerKeyHash'])));
+    }
+
+    public function testWhenGenerateCertificateIdWithSha256IsSuccess(): void
+    {
+        $result = (new Ocsp)->generateCertificateId(
+            (new CertificateLoader)->fromFile(__DIR__ . '/../_resources/revoked.crt')->getCert(), 
+            (new CertificateLoader)->fromFile(__DIR__ . '/../_resources/revoked.issuer.crt')->getCert(),
+            HashAlgorithm::SHA256
+        );
+
+        $this->assertEquals("2.16.840.1.101.3.4.2.1", $result['hashAlgorithm']['algorithm']);
+        $this->assertEquals([95, 66, 108, 14, 230, 221, 220, 19, 204, 150, 46, 50, 249, 230, 243, 173, 85, 145, 220, 162, 11, 98, 80, 34, 131, 168, 252, 178, 130, 128, 58, 168], array_values(unpack('C*', $result['issuerNameHash'])));
+        $this->assertEquals([171, 181, 182, 119, 64, 116, 118, 100, 255, 11, 197, 252, 216, 32, 39, 48, 158, 67, 174, 62, 32, 137, 104, 62, 240, 236, 220, 228, 44, 99, 167, 49], array_values(unpack('C*', $result['issuerKeyHash'])));
     }
 
     public function testWhenMissingSerialNumberInSubjectCertificateThrow(): void


### PR DESCRIPTION
The hash algorith is SHA1 by default. But it is possible to select the algorithm from a predefined set of algorithms described in HashAlgorithm.php

WE2-1022

Signed-off-by: Mihkel Kivisild <mihkel.kivisild@cgi.com>