### PR TITLE
Fix warning Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead

### DIFF
--- a/src/validator/ocsp/OcspClientImpl.php
+++ b/src/validator/ocsp/OcspClientImpl.php
@@ -37,13 +37,13 @@ class OcspClientImpl implements OcspClient
     private int $requestTimeout;
     private $logger;
 
-    public function __construct(int $ocspRequestTimeout, LoggerInterface $logger = null)
+    public function __construct(int $ocspRequestTimeout, ?LoggerInterface $logger = null)
     {
         $this->requestTimeout = $ocspRequestTimeout;
         $this->logger = $logger;
     }
 
-    public static function build(int $ocspRequestTimeout, LoggerInterface $logger = null): OcspClient
+    public static function build(int $ocspRequestTimeout, ?LoggerInterface $logger = null): OcspClient
     {
         return new OcspClientImpl($ocspRequestTimeout, $logger);
     }


### PR DESCRIPTION
WE2-918

Signed-off-by: Sven Mitt <svenzik@users.noreply.github.com>
